### PR TITLE
Fix kv parsing to allow equal sign in value

### DIFF
--- a/src/clique_error.erl
+++ b/src/clique_error.erl
@@ -63,8 +63,6 @@ format(_Cmd, {error, {invalid_flag_combination, Msg}}) ->
     status(io_lib:format("Error: ~ts", [Msg]));
 format(_Cmd, {error, {invalid_value, Val}}) ->
     status(io_lib:format("Invalid value: ~p", [Val]));
-format(_Cmd, {error, {too_many_equal_signs, Arg}}) ->
-    status(io_lib:format("Too many equal signs in argument: ~p", [Arg]));
 format(_Cmd, {error, {invalid_config_keys, Invalid}}) ->
     status(io_lib:format("Invalid config keys: ~ts", [Invalid]));
 format(_Cmd, {error, {invalid_config, {error, [_H|_T]=Msgs}}}) ->

--- a/src/clique_parser.erl
+++ b/src/clique_parser.erl
@@ -84,8 +84,9 @@ parse_kv_args([Arg | Args], Acc) ->
             parse_kv_args(Args, [{Key, Val} | Acc]);
         [Key] ->
             {error, {invalid_kv_arg, Key}};
-        _ ->
-            {error, {too_many_equal_signs, Arg}}
+        [Key | ValTokens] ->
+            GluedValTokens = string:join(ValTokens, "="),
+            parse_kv_args(Args, [{Key, GluedValTokens} | Acc])
     end.
 
 
@@ -368,6 +369,13 @@ parse_valid_args_and_flag_test() ->
     {Spec, Args, Flags} = parse({Spec, ArgsAndFlags}),
     ?assertEqual(Args, [{"key", "value"}]),
     ?assertEqual(Flags, [{$n, Node}]).
+
+parse_valid_arg_value_with_equal_sign_test() ->
+    Spec = spec(),
+    ArgsAndFlags = ["url=example.com?q=dada"],
+    {Spec, Args, Flags} = parse({Spec, ArgsAndFlags}),
+    ?assertEqual(Args, [{"url", "example.com?q=dada"}]),
+    ?assertEqual(Flags, []).
 
 %% All arguments must be of type k=v
 parse_invalid_kv_arg_test() ->


### PR DESCRIPTION
Allow = in value of kv arguments.
Example: my-cli do-something url=example.com?q=dada

Props to @baranga for PR at https://github.com/basho/clique/pull/86