### PR TITLE
Rel 0.3.6 verne

### DIFF
--- a/src/clique_parser.erl
+++ b/src/clique_parser.erl
@@ -84,6 +84,8 @@ parse_kv_args([Arg | Args], Acc) ->
     case IdxEqual of
         0 ->
             {error, {invalid_kv_arg, Arg}};
+        1 ->
+            {error, {invalid_kv_arg, Arg}};
         IdxEnd ->
             {error, {invalid_kv_arg, Arg}};
         _ ->
@@ -393,6 +395,9 @@ parse_invalid_kv_arg_test() ->
     %% Argument with equal sign and no value
     ArgsNoVal = ["ayo="],
     ?assertMatch({error, {invalid_kv_arg, _}}, parse({Spec, ArgsNoVal})),
+    %% Argument with equal sign and no key
+    ArgsNoKey = ["=ayo"],
+    ?assertMatch({error, {invalid_kv_arg, _}}, parse({Spec, ArgsNoKey})),
     %% Argument without equal sign and no value
     ArgsNoEqualAndNoVal = ["ayo"],
     ?assertMatch({error, {invalid_kv_arg, _}}, parse({Spec, ArgsNoEqualAndNoVal})).


### PR DESCRIPTION
I tested this on vernemq custom build on master branch and it fixes https://github.com/vernemq/vernemq/issues/1673.

I checked out currently used vernemq fork of clique and it supports only rebar1,
OTP 20+ solution would be:

```erlang
parse_kv_args([Arg | Args], Acc) ->
    case string:split(Arg, "=") of
        [Key] ->
            {error, {invalid_kv_arg, Key}};
        [Key, []] ->
            {error, {invalid_kv_arg, Key}};
        [[], Val] ->
            {error, {invalid_kv_arg, Val}};
        [Key, Val] ->
            parse_kv_args(Args, [{Key, Val} | Acc])
    end.
```